### PR TITLE
Parameters string fix

### DIFF
--- a/lib/endpoints/projects.js
+++ b/lib/endpoints/projects.js
@@ -149,7 +149,7 @@ function parametersPayload(data) {
 }
 
 function getParameterEntry(name, value) {
-  return {name: name, value: JSON.stringify(value)};
+  return {name: name, value: "" + value};
 }
 
 function projectPayload(data) {

--- a/test/nock/projects/deleteAllParameters/shouldremoveallexistingparameters
+++ b/test/nock/projects/deleteAllParameters/shouldremoveallexistingparameters
@@ -5,12 +5,12 @@
         "path": "/httpAuth/app/rest/projects/id:ParametersTestProject/parameters",
         "body": {
             "name": "parameter_one",
-            "value": "\"value\""
+            "value": "value"
         },
         "status": 200,
         "response": {
             "name": "parameter_one",
-            "value": "\"value\"",
+            "value": "value",
             "own": true
         },
         "headers": {

--- a/test/nock/projects/setParameter/shouldsetparameter'myTestValueString'on<Rootproject>
+++ b/test/nock/projects/setParameter/shouldsetparameter'myTestValueString'on<Rootproject>
@@ -1,0 +1,28 @@
+[
+    {
+        "scope": "http://localhost:8111",
+        "method": "POST",
+        "path": "/httpAuth/app/rest/projects/name:%3CRoot%20project%3E/parameters",
+        "body": {
+            "name": "myTestValueString",
+            "value": "Test String Value"
+        },
+        "status": 200,
+        "response": {
+            "name": "myTestValueString",
+            "value": "Test String Value"
+        },
+        "headers": {
+            "server": "Apache-Coyote/1.1",
+            "set-cookie": [
+                "TCSESSIONID=7A97F9794EE96F282E10752AF10C21B7; Path=/; HttpOnly",
+                "RememberMe=\"\"; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly"
+            ],
+            "cache-control": "no-store",
+            "content-type": "application/json",
+            "transfer-encoding": "chunked",
+            "date": "Mon, 26 Sep 2016 17:49:57 GMT",
+            "connection": "close"
+        }
+    }
+]

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -63,7 +63,7 @@ describe("#projects", function () {
 
     it("should create a project under id:_Root", function () {
       var projectName = "Project Creation Test";
-      
+
       return teamcity.projects.create(projectName, "_Root")
         .then(function (result) {
           expect(result).to.exist;
@@ -83,6 +83,17 @@ describe("#projects", function () {
         .then(function (result) {
           expect(result).to.exist;
           expect(result).to.have.property("name", "myTestValue");
+          expect(result).to.have.property("value", "" + tsValue);
+        });
+    });
+
+    it("should set parameter 'myTestValueString' on <Root project>", function () {
+      var tsValue = "Test String Value";
+
+      return teamcity.projects.setParameter({name: "<Root project>"}, "myTestValueString", tsValue)
+        .then(function (result) {
+          expect(result).to.exist;
+          expect(result).to.have.property("name", "myTestValueString");
           expect(result).to.have.property("value", "" + tsValue);
         });
     });


### PR DESCRIPTION
Fixes a bug where setting a parameter value to a string was surrounding it with double quotes. Added test case for this.
